### PR TITLE
ci speed up

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -5,50 +5,9 @@ on:
     branches: [main]
 
 jobs:
-  continuous-integration:
-    runs-on: ubuntu-latest
-    env:
-      DB: ${{ secrets.DB }}
-      DB_PORT: ${{ secrets.DB_PORT }}
-      DB_PWD: ${{ secrets.DB_PWD }}
-      DB_TYPE: ${{ secrets.DB_TYPE }}
-      DB_URL: ${{ secrets.DB_URL }}
-      DB_USER: ${{ secrets.DB_USER }}
-      ENABLE_MULTITHREADING: ${{ secrets.ENABLE_MULTITHREADING }}
-      ENV_DEV_CLIENT: ${{ secrets.ENV_DEV_CLIENT }}
-      ENV_LOCAL_CLIENT: ${{ secrets.ENV_LOCAL_CLIENT }}
-      ENV_PROD_CLIENT: ${{ secrets.ENV_PROD_CLIENT }}
-      ENV_LOCAL_SERVER: ${{ secrets.ENV_LOCAL_SERVER }}
-      ENV_DEV_SERVER: ${{ secrets.ENV_DEV_SERVER }}
-      ENV_PROD_SERVER: ${{ secrets.ENV_PROD_SERVER }}
-      LOG_LEVEL: ${{ secrets.LOG_LEVEL }}
-      MAIL_PWD: ${{ secrets.MAIL_PWD }}
-      MAIL_USER: ${{ secrets.MAIL_USER }}
-      PORT: ${{ secrets.PORT }}
-      SESSION_ID: ${{ secrets.SESSION_ID }}
-      SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
-      TARGET_ENV: ${{ secrets.TARGET_ENV }}
-      SECONDARY_TEST_EMAIL: ${{ secrets.SECONDARY_TEST_EMAIL }}
-      TIMEOUT_MULTIPLIER: ${{ secrets.TIMEOUT_MULTIPLIER }}
-    if: "(!contains(github.event.head_commit.message, 'pipeline skip') && !contains(github.event.head_commit.message, 'skip pipeline')) || (!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci'))"
-    steps:
-      - uses: actions/checkout@v2
-      - id: ci
-        uses: ./.github/actions/ci
-      - name: Publish npm log
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          name: "npm-log"
-          path: "/home/runner/.npm/_logs"
-      - name: Publish test results
-        if: always()
-        uses: ./.github/actions/publish
-
   continuous-deployment:
     if: "(!contains(github.event.head_commit.message, 'pipeline skip') && !contains(github.event.head_commit.message, 'skip pipeline')) || (!contains(github.event.head_commit.message, 'cd skip') && !contains(github.event.head_commit.message, 'skip cd'))"
     runs-on: ubuntu-latest
-    needs: continuous-integration
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,11 @@ on:
     branches:
       - "*"
       - "!main"
+      - "!develop"
   pull_request:
     branches:
-      - "*"
+      - "main"
+      - "develop"
 
 jobs:
   check-formatting:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "capstone-server",
-    "version": "1.0.66",
+    "version": "1.0.67",
     "description": "My Capstone",
     "engines": {
         "node": "14.17.5"


### PR DESCRIPTION
- bump version "$(./bin/files/get_version_from_package_json.sh)" [skip ci]
- stop double running tests, when merging pull requests, and speed up release cycle as main gets merged from develop, and develop is tested twice already
