### PR TITLE
test and cd fixes

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -12,9 +12,6 @@ runs:
       uses: "./.github/actions/changed"
     - id: cache-node-modules
       uses: ./.github/actions/cache-node-modules
-    - name: check shell
-      run: echo $SHELL
-      shell: bash
     - name: test
       run: |
         npm run test -- --changedSince "${{ steps.changed.outputs.changed }}"

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -12,6 +12,9 @@ runs:
       uses: "./.github/actions/changed"
     - id: cache-node-modules
       uses: ./.github/actions/cache-node-modules
+    - name: check shell
+      run: echo $SHELL
+      uses: bash
     - name: test
       run: |
         npm run test -- --changedSince "${{ steps.changed.outputs.changed }}"

--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -14,7 +14,7 @@ runs:
       uses: ./.github/actions/cache-node-modules
     - name: check shell
       run: echo $SHELL
-      uses: bash
+      shell: bash
     - name: test
       run: |
         npm run test -- --changedSince "${{ steps.changed.outputs.changed }}"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: build
         run: npm run build
       - name: create artifact
-        run: zip -r deploy.zip ./build/* Procfile Buildfile package.json package-lock.json .ebextensions .platform
+        run: zip -r deploy.zip ./build/* package.json package-lock.json .ebextensions .platform
       - name: upload artifact
         run: aws s3 cp deploy.zip s3://${{ secrets.AWS_S3_ARTIFACT_BUCKET }}/${{ secrets.AWS_S3_ARTIFACT_LOCATION }}deploy_${{ steps.version.outputs.VERSION }}.zip
       - name: create application version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: set npm shell
+        run: npm config set script-shell /bin/bash
+        shell: bash
       - id: ci
         uses: ./.github/actions/ci
       - name: build

--- a/Buildfile
+++ b/Buildfile
@@ -1,1 +1,0 @@
-make: npm i

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: pwd && ls -la && npm start

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 <br />
 ![Continuous Integration](https://github.com/noahvarghese/capstone-server/actions/workflows/ci.yaml/badge.svg)
 <br />
-![Statements](https://img.shields.io/badge/statements-74.21%25-red.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-77.76%25-red.svg?style=flat)
 <br />
-![Lines](https://img.shields.io/badge/lines-72.3%25-red.svg?style=flat)
+![Lines](https://img.shields.io/badge/lines-76.04%25-red.svg?style=flat)
 <br />
-![Functions](https://img.shields.io/badge/functions-86.17%25-yellow.svg?style=flat)
+![Functions](https://img.shields.io/badge/functions-94.73%25-brightgreen.svg?style=flat)
 <br />
-![Branches](https://img.shields.io/badge/branches-47.42%25-red.svg?style=flat)
+![Branches](https://img.shields.io/badge/branches-51.82%25-red.svg?style=flat)
 
 # OnBoard - Backend
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,25 +1,19 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-disable no-undef */
-const { pathsToModuleNameMapper } = require("ts-jest/utils");
+import Logs from "@util/logs/logs";
+import { pathsToModuleNameMapper } from "ts-jest/utils";
+import { compilerOptions } from "./tsconfig.json";
 
-const { compilerOptions } = require("./tsconfig");
+Logs.Event("Jest config loaded");
 
-module.exports = {
+export default {
     bail: true,
     collectCoverage: true,
-    collectCoverageFrom: ["**/*.ts"],
     coverageDirectory: "./__test__/coverage",
+    collectCoverageFrom: ["src/**/*.ts"],
     coveragePathIgnorePatterns: [
         "node_modules",
-        "database",
-        "bin",
-        "build",
-        "test.ts",
-        "__test__",
-        "src/util",
-        "src/services",
-        "src/config",
         "src/index.ts",
+        "src/util/logs",
+        "src/services",
     ],
     coverageReporters: ["json-summary", "text", "lcov", "clover"],
     detectOpenHandles: true,
@@ -30,7 +24,8 @@ module.exports = {
     moduleDirectories: ["node_modules", "./"],
     moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
     moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths),
-    setupFilesAfterEnv: ["./jest.setup.js"],
+    setupFiles: ["dotenv/config"],
+    setupFilesAfterEnv: ["./jest.setup.ts"],
     reporters: [
         "default",
         [

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,8 +1,6 @@
-/* eslint-disable no-undef */
-/* eslint-disable @typescript-eslint/no-var-requires */
-const dotenv = require("dotenv");
+import Logs from "@util/logs/logs";
 
-dotenv.config();
+Logs.Event("Jest setup loaded");
 
 const { TIMEOUT_MULTIPLIER } = process.env;
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "node": "14.17.5"
     },
     "scripts": {
+        "enable:recursive": "shopt -s globstar",
         "database:reset": "python3 ./bin/database/reset/main.py --files ./database --path .env",
         "database:reset:test": "npm run database:reset -- -t",
         "database:reset:dev": "npm run database:reset -- -d",
@@ -17,15 +18,15 @@
         "prebuild": "npm run module-alias",
         "build": "rm -rf ./build && tsc -p ./tsconfig.build.json",
         "build:local": "npm run build && cp .env ./build",
-        "postbuild": "npm run postbuild:email-templates && npm run module-alias:cleanup && npm run postbuild:package",
+        "postbuild": "npm run postbuild:email-templates && npm run postbuild:package && npm run module-alias:cleanup",
         "postbuild:email-templates": "cp -R ./src/services/email/templates ./build/services/email",
-        "postbuild:package": "cp ./package*.json ./build && cd build && npm ci",
+        "postbuild:package": "cp ./package*.json ./build && cd build && npm install --only=production",
         "format": "prettier --write \"**/*.ts\" \"*.json\" \"*.js\"",
         "format:check": "prettier --check \"**/*.ts\"",
         "start:dev": "NODE_ENV=dev nodemon -e ts,.env,json --ignore build/ --ignore __test__/ --exec ts-node ./src/index.ts -- dev",
         "start": "NODE_ENV=prod node ./index.js",
-        "test": "NODE_ENV=test jest --runInBand",
-        "test:debug": "NODE_ENV=test node --inspect-brk ./node_modules/.bin/jest --runInBand",
+        "test": "npm run enable:recursive && NODE_ENV=test jest --runInBand",
+        "test:debug": "npm run enable:recursive && NODE_ENV=test node --inspect-brk ./node_modules/.bin/jest --runInBand",
         "test:recent": "npm run test -- -o",
         "test:watch": "npm run test -- --watch",
         "version:bump": "npm version patch -m 'version bump [skip pipeline]'"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "node": "14.17.5"
     },
     "scripts": {
-        "enable:recursive": "shopt -s globstar",
+        "enable:recursive": "$(command -v shopt &>/dev/null) && shopt -s globstar ;",
         "database:reset": "python3 ./bin/database/reset/main.py --files ./database --path .env",
         "database:reset:test": "npm run database:reset -- -t",
         "database:reset:dev": "npm run database:reset -- -d",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,7 +11,6 @@
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "typeRoots": ["@types", "./node_modules/@types"],
-        "resolveJsonModule": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "noImplicitThis": true,
@@ -35,5 +34,5 @@
         "require": ["tsconfig-paths/register"]
     },
     "include": ["./**/*.ts"],
-    "exclude": ["./**/*.test.ts", "__test__/*"]
+    "exclude": ["./**/*.test.ts", "__test__/*", "./jest.*.ts"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,6 +11,7 @@
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "typeRoots": ["@types", "./node_modules/@types"],
+        "resolveJsonModule": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "noImplicitThis": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "outDir": "./build",
+        "resolveJsonModule": true,
         "paths": {
             "@config/*": ["src/config/*"],
             "@middleware/*": ["src/middleware/*"],


### PR DESCRIPTION
- removed unnecessary build and start commands as they are the default commands by aws
- added ability to import from json modules
- added command to enable '**' to recurse, reordered a command, applied recursive command prior to test, and install only production packages in postbuild
- converted jest files to ts, changed coverage configuration to work as it didn't like the build folders
- updated badges after running all tests
- added check for shopt command
- added test
- type
- should have fixed problem
- removed debug output and added option to fix build
- fixed build process by excluding the new ts files
